### PR TITLE
Generalize notifier and add kafka as a backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ sudo: required
 language: go
 before_install:
 - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-- sudo apt-get install -y libmagic-dev
+- wget -qO - https://packages.confluent.io/deb/5.2/archive.key | sudo apt-key add -
+- sudo add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/5.2 stable main"
+- sudo apt-get update
+- sudo apt-get install -y libmagic-dev librdkafka-dev
 go:
 - 1.12.1
 services:
@@ -11,7 +14,6 @@ install:
 - dep ensure
 - go get github.com/rakyll/statik
 script:
-- rm -rf /home/travis/.cache/go-build/*
 - make check
 branches:
   only:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,61 +3,103 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:2d539f7a39608e46451dc04c5ae52063b66588c74ad96b5fa4f55602fa958867"
   name = "github.com/agis/spawn"
   packages = ["."]
+  pruneopts = ""
   revision = "ff42eda08af2d6d0a2819d99a49c4beb59b0a1b6"
 
 [[projects]]
+  digest = "1:82b6c6a7f7f55495200481260dc7d81b3568d2f7e27310d3e6e4df2b7b8b7659"
+  name = "github.com/confluentinc/confluent-kafka-go"
+  packages = ["kafka"]
+  pruneopts = ""
+  revision = "5e4d04e05fc319ce5996a867aafef29059f26862"
+  version = "v0.11.4"
+
+[[projects]]
+  digest = "1:684664f6d28c17faefd0e9824ccaae8a673c25b4fad17d2659c1ff36c6fe1c81"
   name = "github.com/go-kit/kit"
   packages = ["log"]
+  pruneopts = ""
   revision = "ca4112baa34cb55091301bdc13b1420a122b1b9e"
   version = "v0.7.0"
 
 [[projects]]
+  digest = "1:6a4a01d58b227c4b6b11111b9f172ec5c17682b82724e58e6daf3f19f4faccd8"
   name = "github.com/go-logfmt/logfmt"
   packages = ["."]
+  pruneopts = ""
   revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:444e514d1bf978654f86095d2fc47dbf2db4c94426bf4611cda379be6d521226"
   name = "github.com/go-redis/redis"
-  packages = [".","internal","internal/consistenthash","internal/hashtag","internal/pool","internal/proto"]
+  packages = [
+    ".",
+    "internal",
+    "internal/consistenthash",
+    "internal/hashtag",
+    "internal/pool",
+    "internal/proto",
+  ]
+  pruneopts = ""
   revision = "73b70592cdaa9e6abdfcfbf97b4a90d80728c836"
   version = "v6.8.0"
 
 [[projects]]
+  digest = "1:9ca737b471693542351e112c9e86be9bf7385e42256893a09ecb2a98e2036f74"
   name = "github.com/go-stack/stack"
   packages = ["."]
+  pruneopts = ""
   revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
   version = "v1.7.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ed9eeebdf24aadfbca57eb50e6455bd1d2474525e0f0d4454de8c8e9bc7ee9a"
   name = "github.com/kr/logfmt"
   packages = ["."]
+  pruneopts = ""
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
+  digest = "1:0de52dec79d82e2b23093a1a3181c1b9564ea2db4bda2e740b453b5f814c911d"
   name = "github.com/rakyll/magicmime"
   packages = ["."]
+  pruneopts = ""
   revision = "9b99294d6b2216897632b9734769d8ce4568681e"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:a5274bdfcc63825d620dbd395605f5039a94c2af784907677cc589fca8b7a028"
   name = "github.com/rakyll/statik"
   packages = ["fs"]
+  pruneopts = ""
   revision = "fd36b3595eb2ec8da4b8153b107f7ea08504899d"
   version = "v0.1.1"
 
 [[projects]]
+  digest = "1:58b484c6ec08df874223d884af3028b3bf0d3606bd44c60d533e161e22dbb7bd"
   name = "github.com/urfave/cli"
   packages = ["."]
+  pruneopts = ""
   revision = "a14d7d367bc02b1f57d88de97926727f2d936387"
   version = "v1.18.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "29cc17e33ef73c5ce8a86777aae6414b00109df84bea6892890ecf92e75db874"
+  input-imports = [
+    "github.com/agis/spawn",
+    "github.com/confluentinc/confluent-kafka-go/kafka",
+    "github.com/go-kit/kit/log",
+    "github.com/go-redis/redis",
+    "github.com/go-stack/stack",
+    "github.com/rakyll/magicmime",
+    "github.com/rakyll/statik/fs",
+    "github.com/urfave/cli",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,3 +17,7 @@
 [[constraint]]
   name = "github.com/go-kit/kit"
   version = "0.7.0"
+
+[[constraint]]
+  name = "github.com/confluentinc/confluent-kafka-go"
+  version = "=0.11.4"

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1,0 +1,40 @@
+package backend
+
+import (
+	"context"
+
+	"github.com/skroutz/downloader/job"
+)
+
+// Backend is the interface that wraps the basic Notify method.
+//
+// Backend implementations are responsible for notifying about a job
+// completion through some notification channel (eg. HTTP, Kafka).
+type Backend interface {
+	// Start() initializes the backend. Start() must be called once, before
+	// any calls to Notify.
+	Start(context.Context, map[string]interface{}) error
+
+	// Notify() notifies about a job completion. Depending on the underlying
+	// implementation, Notify might be an asynchronous operation so a nil
+	// error does NOT necessarily mean the notification was delivered.
+	// To check for the result of a notification use DeliveryReports().
+	//
+	// Implementations should peek job.CallbackDst to determine the
+	// destination of the notification.
+	Notify(string, job.Callback) error
+
+	// ID returns a constant string used as an identifier for the
+	// concrete backend implementation.
+	ID() string
+
+	// DeliveryReports() is used to communicate the results of notifications.
+	//
+	// Even if a message received from this channel is successful that
+	// does not mean that the callback has been consumed on the other end.
+	DeliveryReports() <-chan job.Callback
+
+	// Stop() closes the delivery reports channel and performs finalization
+	// actions. After calling Stop() the backend is no longer usable.
+	Stop() error
+}

--- a/backend/http_backend/http_backend.go
+++ b/backend/http_backend/http_backend.go
@@ -1,0 +1,108 @@
+package httpbackend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/skroutz/downloader/job"
+)
+
+// DefaultClientTimeoutSec defines a default timeout in seconds for our http client
+const DefaultClientTimeoutSec = 30
+
+var (
+	// Based on http.DefaultTransport
+	//
+	// See https://golang.org/pkg/net/http/#RoundTripper
+	transport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second, // was 30 * time.Second
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	clientTimeout time.Duration
+)
+
+// Backend notifies about a job completion by executing an HTTP request.
+type Backend struct {
+	client  *http.Client
+	reports chan job.Callback
+}
+
+// ID returns "http"
+func (b *Backend) ID() string {
+	return "http"
+}
+
+// Start starts the backend based on configuration provided by cfg.
+func (b *Backend) Start(ctx context.Context, cfg map[string]interface{}) error {
+	cfgTimeout, ok := cfg["timeout"]
+	if !ok {
+		clientTimeout = time.Duration(DefaultClientTimeoutSec) * time.Second
+	} else {
+		t, err := cfgTimeout.(json.Number).Int64()
+		if err != nil {
+			return err
+		}
+		clientTimeout = time.Duration(t) * time.Second
+	}
+
+	b.client = &http.Client{
+		Transport: transport,
+		Timeout:   clientTimeout, // Larger than Dial + TLS timeouts
+	}
+
+	b.reports = make(chan job.Callback)
+
+	return nil
+}
+
+// Notify notifies a url about a job completion denoted by cbInfo.
+func (b *Backend) Notify(url string, cbInfo job.Callback) error {
+	payload, err := cbInfo.Bytes()
+	if err != nil {
+		cbInfo.Delivered = false
+		cbInfo.DeliveryError = err.Error()
+		return err
+	}
+
+	res, err := b.client.Post(url, "application/json", bytes.NewBuffer(payload))
+	if err != nil || res.StatusCode < 200 || res.StatusCode >= 300 {
+		if err == nil {
+			err = fmt.Errorf("Received Status: %s", res.Status)
+		}
+		cbInfo.Delivered = false
+		cbInfo.DeliveryError = err.Error()
+		return err
+	}
+
+	cbInfo.Delivered = true
+	cbInfo.DeliveryError = ""
+	b.reports <- cbInfo
+
+	return nil
+}
+
+// DeliveryReports returns a channel of successfully emmited callbacks.
+// Failures are returned directly by Notify() as errors.
+func (b *Backend) DeliveryReports() <-chan job.Callback {
+	return b.reports
+}
+
+// Stop shuts down the backend
+func (b *Backend) Stop() error {
+	close(b.reports)
+	return nil
+}

--- a/backend/http_backend/http_backend_test.go
+++ b/backend/http_backend/http_backend_test.go
@@ -1,0 +1,78 @@
+package httpbackend
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/skroutz/downloader/config"
+	"github.com/skroutz/downloader/job"
+)
+
+var (
+	cbServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	httpB *Backend
+	ctx   context.Context
+	jobS  *job.Job
+	dwURL *url.URL
+)
+
+func init() {
+	ctx = context.Background()
+	dwURL, _ = url.Parse("http://blah.com/")
+	jobS = &job.Job{
+		ID:            "successjob",
+		URL:           "http://localhost:12345",
+		AggrID:        "notifoo",
+		DownloadState: job.StateSuccess,
+		CallbackURL:   cbServer.URL,
+		ResponseCode:  200,
+	}
+}
+
+func TestHttpBackendNotifySucess(t *testing.T) {
+	var wg sync.WaitGroup
+
+	testCfgFile := "../../config.test.json"
+	cfg, err := config.Parse(testCfgFile)
+	if err != nil {
+		t.Fatalf("Could not load test configuration %s. Operation returned %s", testCfgFile, err)
+	}
+
+	httpB = &Backend{}
+
+	err = httpB.Start(ctx, cfg.Backends["http"])
+	if err != nil {
+		t.Fatalf("Start should not return error")
+	}
+
+	cbInfoS, _ := jobS.CallbackInfo(*dwURL)
+
+	wg.Add(1)
+	go func() {
+		err := httpB.Notify(jobS.CallbackURL, cbInfoS)
+		if err != nil {
+			t.Fatalf("Expected Notify to be successful")
+		}
+		wg.Done()
+	}()
+
+	time.Sleep(2 * time.Second)
+
+	cbInfo := <-httpB.DeliveryReports()
+	if !cbInfo.Delivered {
+		t.Fatalf("Expected callback delivery to be successful")
+	}
+
+	err = httpB.Stop()
+	if err != nil {
+		t.Fatalf("Error while finalizing %s ", err)
+	}
+	wg.Wait()
+}

--- a/backend/kafka_backend/kafka_backend.go
+++ b/backend/kafka_backend/kafka_backend.go
@@ -1,0 +1,130 @@
+package kafkabackend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/skroutz/downloader/job"
+)
+
+// FlushTimeout is the timeout we give to our kafka producer
+// to flush pending messages.
+const FlushTimeout = 5000
+
+// Backend notifies about a job completion by producing to a Kafka topic.
+type Backend struct {
+	producer *kafka.Producer
+	reports  chan job.Callback
+	eventsWg *sync.WaitGroup
+}
+
+// ID returns "kafka".
+func (b *Backend) ID() string {
+	return "kafka"
+}
+
+// Start starts the backend by creating a producer,
+// given a set of options provided by the configuration.
+func (b *Backend) Start(ctx context.Context, cfg map[string]interface{}) error {
+	var err error
+
+	kafkaCfg := make(kafka.ConfigMap)
+	for k, v := range cfg {
+		err := kafkaCfg.SetKey(k, v)
+		if err != nil {
+			return err
+		}
+	}
+
+	b.producer, err = kafka.NewProducer(&kafkaCfg)
+	if err != nil {
+		return err
+	}
+
+	b.reports = make(chan job.Callback)
+	b.eventsWg = new(sync.WaitGroup)
+
+	// start a go routine to monitor Kafka's Events channel
+	b.eventsWg.Add(1)
+	go func() {
+		defer b.eventsWg.Done()
+		b.transformStream(ctx)
+	}()
+
+	return nil
+}
+
+// Notify produces a Kafka message to topic.
+func (b *Backend) Notify(topic string, cbInfo job.Callback) error {
+	payload, err := cbInfo.Bytes()
+	if err != nil {
+		return err
+	}
+
+	message := &kafka.Message{
+		TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
+		Value:          payload,
+	}
+
+	return b.producer.Produce(message, nil)
+}
+
+// DeliveryReports returns a channel of emmited callback events
+func (b *Backend) DeliveryReports() <-chan job.Callback {
+	return b.reports
+}
+
+// Stop gracefully terminates b after flushing any outstanding messages to Kafka.
+// An error is returned if (and only if) not all messages were flushed.
+func (b *Backend) Stop() error {
+	var err error
+
+	unflushed := b.producer.Flush(FlushTimeout)
+	if unflushed > 0 {
+		err = fmt.Errorf("After %d ms there were still %d unflushed messages", FlushTimeout, unflushed)
+	}
+
+	b.producer.Close()
+	b.eventsWg.Wait()
+	close(b.reports)
+
+	return err
+}
+
+// transformStream iterates over the Events channel of Kafka, transforms
+// each message to a callback info object and enqueues the callback object
+// to b.reports channel.
+func (b *Backend) transformStream(ctx context.Context) {
+	for {
+		select {
+		case e, ok := <-b.producer.Events():
+			if !ok {
+				return
+			}
+
+			switch ev := e.(type) {
+			case *kafka.Message:
+				var cbInfo job.Callback
+
+				err := json.Unmarshal(ev.Value, &cbInfo)
+				if err != nil {
+					cbInfo.Delivered = false
+					cbInfo.DeliveryError = fmt.Sprintf("Could not unmarshall Value %s to callback object", ev.Value)
+				} else {
+					cbInfo.Delivered = true
+					cbInfo.DeliveryError = ""
+
+					if ev.TopicPartition.Error != nil {
+						cbInfo.Delivered = false
+						cbInfo.DeliveryError = ev.TopicPartition.Error.Error()
+					}
+				}
+
+				b.reports <- cbInfo
+			}
+		}
+	}
+}

--- a/config.json
+++ b/config.json
@@ -14,5 +14,18 @@
 		"download_url": "http://localhost/foo",
 		"concurrency": 10,
 		"stats_interval": 5000
+	},
+	"backends": {
+		"http": {
+			"timeout": 30
+		},
+		"kafka": {
+			"bootstrap.servers": "localhost:9092",
+			"api.version.request": true,
+			"log.connection.close": false,
+			"go.delivery.reports": true,
+			"message.send.max.retries": 3,
+			"request.required.acks": -1
+		}
 	}
 }

--- a/config.json
+++ b/config.json
@@ -13,7 +13,8 @@
 	"notifier": {
 		"download_url": "http://localhost/foo",
 		"concurrency": 10,
-		"stats_interval": 5000
+		"stats_interval": 5000,
+		"deletion_interval": 180
 	},
 	"backends": {
 		"http": {

--- a/config.test.json
+++ b/config.test.json
@@ -13,7 +13,8 @@
 	"notifier": {
 		"download_url": "http://localhost/foo",
 		"concurrency": 10,
-		"stats_interval": 300
+		"stats_interval": 300,
+		"deletion_interval": 1
 	},
 	"backends": {
 		"http": {

--- a/config.test.json
+++ b/config.test.json
@@ -14,5 +14,10 @@
 		"download_url": "http://localhost/foo",
 		"concurrency": 10,
 		"stats_interval": 300
+	},
+	"backends": {
+		"http": {
+			"timeout": 30
+		}
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -22,9 +22,10 @@ type Config struct {
 	} `json:"processor"`
 
 	Notifier struct {
-		DownloadURL   string `json:"download_url"`
-		Concurrency   int    `json:"concurrency"`
-		StatsInterval int    `json:"stats_interval"`
+		DownloadURL      string `json:"download_url"`
+		Concurrency      int    `json:"concurrency"`
+		StatsInterval    int    `json:"stats_interval"`
+		DeletionInterval int    `json:"deletion_interval"`
 	} `json:"notifier"`
 
 	Backends map[string]map[string]interface{}

--- a/config/config.go
+++ b/config/config.go
@@ -26,8 +26,11 @@ type Config struct {
 		Concurrency   int    `json:"concurrency"`
 		StatsInterval int    `json:"stats_interval"`
 	} `json:"notifier"`
+
+	Backends map[string]map[string]interface{}
 }
 
+// Parse loads a given file name and creates a Configuration
 func Parse(filename string) (Config, error) {
 	cfg := Config{}
 	f, err := os.Open(filename)

--- a/contrib/fabfile.py
+++ b/contrib/fabfile.py
@@ -1,6 +1,8 @@
 """
 Deploy Downloader with fabric
 
+Note: Needs fabric 1.x
+
 Usage:
 
 $ ln -s contrib/fabfile.py

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agis/spawn"
 
 	"github.com/skroutz/downloader/config"
-	"github.com/skroutz/downloader/notifier"
+	"github.com/skroutz/downloader/job"
 )
 
 type testJob map[string]interface{}
@@ -187,7 +187,7 @@ func TestResourceExists(t *testing.T) {
 	}
 
 	// Test callback mechanism (Notifier)
-	var ci notifier.CallbackInfo
+	var ci job.Callback
 
 	select {
 	case <-time.After(timeout):
@@ -281,7 +281,7 @@ FILECHECK:
 }
 
 func TestResourceDontExist(t *testing.T) {
-	var ci notifier.CallbackInfo
+	var ci job.Callback
 
 	resourceURL := downloadURL("i-dont-exist.foo")
 	job := testJob{
@@ -328,7 +328,7 @@ func TestResourceDontExist(t *testing.T) {
 }
 
 func TestMimeTypeMismatch(t *testing.T) {
-	var ci notifier.CallbackInfo
+	var ci job.Callback
 
 	resourceURL := downloadURL("tiny.png")
 	job := testJob{
@@ -363,7 +363,7 @@ func TestMimeTypeMismatch(t *testing.T) {
 
 // test a download URL that will fail the first 2 times but succeeds the 3rd
 func TestTransientDownstreamError(t *testing.T) {
-	var ci notifier.CallbackInfo
+	var ci job.Callback
 
 	resourceURL := fmt.Sprintf("http://%s:%s%ssample-1.jpg", fsHost, fsPort, fsPath)
 
@@ -416,7 +416,7 @@ func TestTransientDownstreamError(t *testing.T) {
 	}
 }
 func TestUnexpectedReadError(t *testing.T) {
-	var ci notifier.CallbackInfo
+	var ci job.Callback
 
 	resourceURL := downloadURL("200")
 
@@ -602,7 +602,7 @@ func TestLoad(t *testing.T) {
 	}
 	close(attrs)
 
-	var ci notifier.CallbackInfo
+	var ci job.Callback
 	results := make(map[bool]int, nreqs)
 
 	for i := 0; i < nreqs; i++ {

--- a/job/callback.go
+++ b/job/callback.go
@@ -1,0 +1,40 @@
+package job
+
+import (
+	"encoding/json"
+)
+
+// Callback holds info to be posted back to the provided callback destination.
+type Callback struct {
+	// Success refers to whether a job download was successful or not
+	Success bool `json:"success"`
+
+	// Error contains errors that occured during a job download
+	Error string `json:"error"`
+
+	// Extra are opaque/pass through data
+	Extra string `json:"extra"`
+
+	// ResourceURL is the url of the requested for download resource
+	ResourceURL string `json:"resource_url"`
+
+	// DownlaodURL the url where the downloaded resource resides
+	DownloadURL string `json:"download_url"`
+
+	// JobID is the unique id of a Job
+	JobID string `json:"job_id"`
+
+	// ResponseCode is the http response for the downloaded resource e.g 200, 404
+	ResponseCode int `json:"response_code"`
+
+	// Delivered signifies where the callback has been delivered or not
+	Delivered bool `json:"delivered"`
+
+	// DeliveryError contains the error occured while delivering a callback
+	DeliveryError string `json:"delivery_error"`
+}
+
+// Bytes returns a byte slice for a callback info encoded as JSON
+func (cb *Callback) Bytes() ([]byte, error) {
+	return json.Marshal(cb)
+}

--- a/main.go
+++ b/main.go
@@ -187,6 +187,14 @@ func main() {
 					notifier.StatsIntvl = time.Duration(cfg.Notifier.StatsInterval) * time.Millisecond
 				}
 
+				if cfg.Notifier.DeletionInterval > 0 {
+					notifier.DeletionIntvl = time.Duration(cfg.Notifier.DeletionInterval) * time.Minute
+				} else {
+					logger.Fatalf("You need to provide a positive integer for the deletion_interval setting. " +
+						"The setting is important and represents the amount of time in minutes, that a file " +
+						"will be scheduled for deletion, after a job's callback has been delivered successfully.")
+				}
+
 				closeChan := make(chan struct{})
 				go notifier.Start(closeChan, cfg.Backends)
 

--- a/main.go
+++ b/main.go
@@ -188,7 +188,7 @@ func main() {
 				}
 
 				closeChan := make(chan struct{})
-				go notifier.Start(closeChan)
+				go notifier.Start(closeChan, cfg.Backends)
 
 				<-sigCh
 				notifier.Log.Println("Shutting down...")

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -54,6 +54,10 @@ type Notifier struct {
 	DownloadURL *url.URL
 	StatsIntvl  time.Duration
 
+	// DeletionIntvl indicates the time after which downloaded files must be
+	// enqueued for deletion.
+	DeletionIntvl time.Duration
+
 	// TODO: These should be exported
 	concurrency int
 	client      *http.Client
@@ -286,6 +290,12 @@ func (n *Notifier) handleCallbackInfo(cbInfo job.Callback) error {
 		if err != nil {
 			return fmt.Errorf("Could not remove job %s. Operation returned error: %s", cbInfo.JobID, err)
 		}
+
+		err = n.Storage.QueueJobForDeletion(cbInfo.JobID, n.DeletionIntvl)
+		if err != nil {
+			return fmt.Errorf("Error: Could not queue job for deletion %s", err)
+		}
+
 		return nil
 	}
 

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -1,14 +1,18 @@
 package notifier
 
 import (
+	"encoding/json"
+	"expvar"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/skroutz/downloader/config"
 	"github.com/skroutz/downloader/job"
+	"github.com/skroutz/downloader/stats"
 	"github.com/skroutz/downloader/storage"
 
 	"github.com/go-redis/redis"
@@ -17,10 +21,12 @@ import (
 var (
 	Redis    *redis.Client
 	cbServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
 	}))
-	store   *storage.Storage
-	logger  = log.New(os.Stderr, "[test-notifier] ", log.Ldate|log.Ltime)
-	testCfg = "../config.test.json"
+	store    *storage.Storage
+	logger   = log.New(os.Stderr, "[test-notifier] ", log.Ldate|log.Ltime)
+	testCfg  = "../config.test.json"
+	Backends map[string]map[string]interface{}
 )
 
 func init() {
@@ -28,6 +34,9 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	Backends = cfg.Backends
+
 	Redis = redis.NewClient(&redis.Options{Addr: cfg.Redis.Addr})
 	err = Redis.FlushDB().Err()
 	if err != nil {
@@ -37,6 +46,79 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func TestUndefinedBackend(t *testing.T) {
+	j := &job.Job{
+		ID:            "successjob",
+		URL:           "http://localhost:12345",
+		AggrID:        "notifoo",
+		DownloadState: job.StateSuccess,
+		CallbackType:  "foo",
+		CallbackDst:   cbServer.URL}
+
+	notifier, err := New(store, 10, logger, "http://blah.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	notifier.StatsIntvl = 50 * time.Millisecond
+
+	notifier.stats = stats.New(statsID, notifier.StatsIntvl, func(m *expvar.Map) {
+		// Store metrics in JSON
+		err := notifier.Storage.SetStats("notifier", m.String(), 2*notifier.StatsIntvl)
+		if err != nil {
+			notifier.Log.Println("Could not report stats", err)
+		}
+	})
+
+	ch := make(chan struct{})
+	go notifier.Start(ch, Backends)
+
+	err = store.QueuePendingCallback(j, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var dataBytes []byte
+	var data string
+
+	type result struct {
+		Alive                        int `json:"alive"`
+		UndefinedBackendWithCallback int `json:"undefinedBackendWithCallback"`
+	}
+
+	for i := 0; i < 5; i++ {
+		time.Sleep(50 * time.Millisecond)
+
+		dataBytes, err = store.GetStats("notifier")
+		if err != nil {
+			t.Fatalf("Error returned while accessing stats %s", err)
+		}
+
+		data = string(dataBytes)
+
+		if data != "" {
+			var r result
+			err = json.Unmarshal(dataBytes, &r)
+			if err != nil {
+				t.Fatalf("Error while unmarsalling to results struct. Error is %s", err)
+			}
+
+			if r.UndefinedBackendWithCallback == 1 {
+				break
+			} else {
+				t.Fatalf("Expected %d Got %d for undefinedBackendWithCallback", 1, r.UndefinedBackendWithCallback)
+			}
+		}
+	}
+
+	if data == "" {
+		t.Fatalf("Did not receive stats data for 250 millis")
+	}
+
+	ch <- struct{}{}
+	<-ch
 }
 
 func TestNotifyJobDeletion(t *testing.T) {
@@ -67,6 +149,9 @@ func TestNotifyJobDeletion(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ch := make(chan struct{})
+	go notifier.Start(ch, Backends)
+
 	for _, tc := range testcases {
 		err := store.QueuePendingCallback(tc.j, 0)
 		if err != nil {
@@ -81,10 +166,7 @@ func TestNotifyJobDeletion(t *testing.T) {
 			t.Fatalf("Expected job with id %s to exist in Redis", tc.j.ID)
 		}
 
-		err = notifier.Notify(tc.j)
-		if err != nil {
-			t.Fatal(err)
-		}
+		time.Sleep(2 * time.Second)
 
 		exists, err = store.JobExists(tc.j)
 		if err != nil {
@@ -94,6 +176,9 @@ func TestNotifyJobDeletion(t *testing.T) {
 			t.Fatalf("Expected job exist to be %v", tc.shouldExist)
 		}
 	}
+
+	ch <- struct{}{}
+	<-ch
 }
 
 func TestRogueCollection(t *testing.T) {
@@ -132,7 +217,7 @@ func TestRogueCollection(t *testing.T) {
 
 	//start and close Notifier
 	ch := make(chan struct{})
-	go notifier.Start(ch)
+	go notifier.Start(ch, Backends)
 	ch <- struct{}{}
 	<-ch
 

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -149,14 +149,17 @@ func TestReaper(t *testing.T) {
 
 	cases := []struct {
 		Job     job.Job
+		Delay   time.Duration
 		InRedis bool
 	}{
 		{
 			job.Job{ID: "RIPinRedis"},
+			time.Minute * 0,
 			true,
 		},
 		{
 			job.Job{ID: "RIPGhost"},
+			time.Minute * 0,
 			false,
 		},
 	}
@@ -174,7 +177,7 @@ func TestReaper(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = store.QueueJobForDeletion(tc.Job.ID)
+		err = store.QueueJobForDeletion(tc.Job.ID, tc.Delay)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -354,6 +354,10 @@ func jobFromMap(m map[string]string) (job.Job, error) {
 			j.DownloadMeta = v
 		case "CallbackURL":
 			j.CallbackURL = v
+		case "CallbackType":
+			j.CallbackType = v
+		case "CallbackDst":
+			j.CallbackDst = v
 		case "CallbackCount":
 			j.CallbackCount, err = strconv.Atoi(v)
 			if err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -222,10 +222,11 @@ func (s *Storage) QueuePendingCallback(j *job.Job, delay time.Duration) error {
 }
 
 // QueueJobForDeletion pushes the provided job id to RIPQueue and returns any errors
-func (s *Storage) QueueJobForDeletion(id string) error {
+// The job deletion can be delayed by the specified delay minutes.
+func (s *Storage) QueueJobForDeletion(id string, delay time.Duration) error {
 	z := redis.Z{
 		Member: id,
-		Score:  float64(time.Now().Unix()),
+		Score:  float64(time.Now().Add(delay).Unix()),
 	}
 	return s.Redis.ZAdd(RIPQueue, z).Err()
 }


### PR DESCRIPTION
Up until now, Notifier was communicating results through HTTP.
This PR refactors the notifier so that it consists of `backends`. This helps, in order
to be able to communicate results not only through HTTP but through other means as well,
such as Kafka.