### PR TITLE
Fix a bug in 'make fmt'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,11 @@
 
 all: fmt build
 
+NEED_REFORMAT := $(shell gofmt -l . | grep -v vendor/)
 fmt:
-	! gofmt -d -e -s *.go **/*.go 2>&1 | tee /dev/tty | read
+	ifneq ($(NEED_REFORMAT),)
+		$(error "Source code needs re-formatting! Use 'go fmt' manually.")
+	endif
 
 deps:
 	dep ensure -v


### PR DESCRIPTION
The latest 'gofmt' output formatting changed resulting in:

> /bin/sh: 1: read: arg count

Thus, we changed the logic to explicitly 'gofmt -l' all Go files except for
those in the vendor/ dir and abort if any formattting error is reported.