### PR TITLE
Respect redis configuration in all tests

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -12,18 +12,25 @@ import (
 
 	klog "github.com/go-kit/kit/log"
 	"github.com/go-redis/redis"
+	"github.com/skroutz/downloader/config"
 	"github.com/skroutz/downloader/job"
 	"github.com/skroutz/downloader/storage"
 )
 
 var (
-	Redis  = redis.NewClient(&redis.Options{Addr: "localhost:6379"})
-	store  *storage.Storage
-	logger klog.Logger
+	Redis   *redis.Client
+	store   *storage.Storage
+	logger  klog.Logger
+	testCfg = "../config.test.json"
 )
 
 func init() {
-	err := Redis.FlushDB().Err()
+	cfg, err := config.Parse(testCfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	Redis = redis.NewClient(&redis.Options{Addr: cfg.Redis.Addr})
+	err = Redis.FlushDB().Err()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
 	},
 	"processor": {
 		"storage_dir":"/tmp/",
-    "user_agent": "Downloader v1",
+		"user_agent": "Downloader v1",
 		"stats_interval": 5000
 	},
 	"notifier": {

--- a/config.test.json
+++ b/config.test.json
@@ -7,7 +7,7 @@
 	},
 	"processor": {
 		"storage_dir":"/tmp/",
-    "user_agent": "Downloader v1",
+		"user_agent": "Downloader v1",
 		"stats_interval": 300
 	},
 	"notifier": {

--- a/config/config.go
+++ b/config/config.go
@@ -1,13 +1,9 @@
-package main
+package config
 
 import (
 	"encoding/json"
 	"os"
-
-	"github.com/urfave/cli"
 )
-
-var cfg Config
 
 // Config holds the app's configuration
 type Config struct {
@@ -32,20 +28,15 @@ type Config struct {
 	} `json:"notifier"`
 }
 
-func parseCliConfig(ctx *cli.Context) error {
-	return parseConfig(ctx.String("config"))
-}
-
-func parseConfig(filename string) error {
+func Parse(filename string) (Config, error) {
+	cfg := Config{}
 	f, err := os.Open(filename)
 	if err != nil {
-		return err
+		return cfg, err
 	}
 	defer f.Close()
 
 	dec := json.NewDecoder(f)
 	dec.UseNumber()
-	dec.Decode(&cfg)
-
-	return nil
+	return cfg, dec.Decode(&cfg)
 }

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-stack/stack"
 	"github.com/skroutz/downloader/api"
+	"github.com/skroutz/downloader/config"
 	"github.com/skroutz/downloader/notifier"
 	"github.com/skroutz/downloader/processor"
 	"github.com/skroutz/downloader/storage"
@@ -28,6 +29,7 @@ import (
 var (
 	sigCh   = make(chan os.Signal, 1)
 	Version string
+	cfg     config.Config
 )
 
 func main() {
@@ -211,6 +213,12 @@ func main() {
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func parseCliConfig(ctx *cli.Context) error {
+	var err error
+	cfg, err = config.Parse(ctx.String("config"))
+	return err
 }
 
 func redisClient(name, addr string) *redis.Client {

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/skroutz/downloader/config"
 	"github.com/skroutz/downloader/job"
 	"github.com/skroutz/downloader/storage"
 
@@ -14,15 +15,21 @@ import (
 )
 
 var (
-	Redis    = redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	Redis    *redis.Client
 	cbServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	}))
-	store  *storage.Storage
-	logger = log.New(os.Stderr, "[test-notifier] ", log.Ldate|log.Ltime)
+	store   *storage.Storage
+	logger  = log.New(os.Stderr, "[test-notifier] ", log.Ldate|log.Ltime)
+	testCfg = "../config.test.json"
 )
 
 func init() {
-	err := Redis.FlushDB().Err()
+	cfg, err := config.Parse(testCfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	Redis = redis.NewClient(&redis.Options{Addr: cfg.Redis.Addr})
+	err = Redis.FlushDB().Err()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -38,7 +38,7 @@ var (
 func TestMain(m *testing.M) {
 	var err error
 
-	storageDir, err = ioutil.TempDir("", "downr-processor-")
+	storageDir, err = ioutil.TempDir("", "downloader-processor-")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/go-redis/redis"
+	"github.com/skroutz/downloader/config"
 	"github.com/skroutz/downloader/job"
 	"github.com/skroutz/downloader/processor/diskcheck"
 	"github.com/skroutz/downloader/storage"
@@ -31,17 +32,23 @@ var (
 	defaultAggr      = job.Aggregation{ID: "FooBar", Limit: 1}
 	defaultProcessor Processor
 	defaultWP        workerPool
+	testCfg          = "../config.test.json"
 )
 
 func TestMain(m *testing.M) {
 	var err error
 
-	storageDir, err = ioutil.TempDir("", "downloader-processor-")
+	storageDir, err = ioutil.TempDir("", "downr-processor-")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	Redis = redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	cfg, err := config.Parse(testCfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	Redis = redis.NewClient(&redis.Options{Addr: cfg.Redis.Addr})
 	err = Redis.FlushDB().Err()
 	if err != nil {
 		log.Fatal(err)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/go-redis/redis"
+	"github.com/skroutz/downloader/config"
 	"github.com/skroutz/downloader/job"
 )
 
 var (
 	Redis   *redis.Client
 	storage *Storage
+	testCfg = "../config.test.json"
 	testJob = job.Job{
 		ID:          "TestJob",
 		URL:         "http://localhost:12345",
@@ -21,14 +23,20 @@ var (
 
 func init() {
 	var err error
-
-	Redis = redis.NewClient(&redis.Options{Addr: "localhost:6379"})
-	storage, err = New(Redis)
+	cfg, err := config.Parse(testCfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	Redis = redis.NewClient(&redis.Options{Addr: cfg.Redis.Addr})
+	err = Redis.FlushDB().Err()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	Redis.FlushDB()
+	storage, err = New(Redis)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func TestSaveJob(t *testing.T) {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -22,7 +22,6 @@ var (
 )
 
 func init() {
-	var err error
 	cfg, err := config.Parse(testCfg)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Previously, Redis configuration was not consistent in all test as some tests were defaulting to `localhost:6379` and other fetched their configuration from test config.