### PR TITLE
Api enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Parameters:
  * `callback_url`: string, The endpoint on which the job callback request will be performed.
  * `extra`: ( optional ) string, Client provided metadata that get passed back in the callback.
  * `mime_type`: ( optional ) string, series of mime types that the download is going to be verified against.
+ * `download_timeout`: ( optional ) int, HTTP client timeout per Job, in seconds.
 
 Output: JSON document containing the download's id e.g, `{"id":"NSb4FOAs9fVaQw"}`
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Parameters:
 
  * `aggr_id`: string, Grouping identifier for the download job.
  * `aggr_limit`: int, Max concurrency limit for the specified group ( aggr_id ).
+ * `aggr_proxy`: ( optional ) string, HTTP proxy configuration. It is set up on aggregation level and it cannot be updated for an existing aggregation.
  * `url`: string, The URL pointing to the resource that will get downloaded.
  * `callback_url`: string, The endpoint on which the job callback request will be performed.
  * `extra`: ( optional ) string, Client provided metadata that get passed back in the callback.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Parameters:
  * `extra`: ( optional ) string, Client provided metadata that get passed back in the callback.
  * `mime_type`: ( optional ) string, series of mime types that the download is going to be verified against.
  * `download_timeout`: ( optional ) int, HTTP client timeout per Job, in seconds.
+ * `user_agent`: ( optional ) string, User-Agent request header per Job.
 
 Output: JSON document containing the download's id e.g, `{"id":"NSb4FOAs9fVaQw"}`
 

--- a/job/aggregation.go
+++ b/job/aggregation.go
@@ -3,6 +3,7 @@ package job
 import (
 	"encoding/json"
 	"errors"
+	"net/url"
 )
 
 // Aggregation is the concept through which the rate limit rules are defined
@@ -12,18 +13,27 @@ type Aggregation struct {
 
 	// Maximum numbers of concurrent download requests
 	Limit int `json:"aggr_limit"`
+
+	// Proxy url for the client to use, optional
+	Proxy string `json:"aggr_proxy"`
 }
 
 // NewAggregation creates an aggregation with the provided ID and limit.
 // If any of the prerequisites fail, an error is returned.
-func NewAggregation(id string, limit int) (*Aggregation, error) {
+func NewAggregation(id string, limit int, proxy string) (*Aggregation, error) {
 	if id == "" {
 		return nil, errors.New("Aggregation ID cannot be empty")
 	}
 	if limit <= 0 {
 		return nil, errors.New("Aggregation limit must be greater than 0")
 	}
-	return &Aggregation{ID: id, Limit: limit}, nil
+
+	if proxy != "" {
+		if _, err := url.ParseRequestURI(proxy); err != nil {
+			return nil, errors.New("Aggregation proxy must be a valid URI: " + err.Error())
+		}
+	}
+	return &Aggregation{ID: id, Limit: limit, Proxy: proxy}, nil
 }
 
 // UnmarshalJSON populates the aggregation with the values in the provided JSON.
@@ -53,8 +63,22 @@ func (a *Aggregation) UnmarshalJSON(b []byte) error {
 		return errors.New("Aggregation limit must be greater than 0")
 	}
 
+	var proxy string
+	if proxyField, ok := tmp["aggr_proxy"]; ok {
+		proxy, ok = proxyField.(string)
+		if !ok {
+			return errors.New("Aggregation proxy must be a string")
+		}
+		if proxy != "" {
+			if _, err := url.ParseRequestURI(proxy); err != nil {
+				return errors.New("Aggregation proxy must be a valid URI: " + err.Error())
+			}
+		}
+	}
+
 	a.ID = id
 	a.Limit = limit
+	a.Proxy = proxy
 
 	return nil
 }

--- a/job/aggregation_test.go
+++ b/job/aggregation_test.go
@@ -1,0 +1,41 @@
+package job
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAggregationUnmarshal(t *testing.T) {
+	tc := map[string]bool{
+		// id
+		`{"aggr_id":"foo", "aggr_limit":4, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`: false,
+		`{"aggr_id":4, "aggr_limit":4, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:     true,
+		`{"aggr_id":"", "aggr_limit":4, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:    true,
+
+		// limit
+		`{"aggr_id":"limitfoo", "aggr_limit":4, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:   false,
+		`{"aggr_id":"limitbar", "aggr_limit":-2, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:  true,
+		`{"aggr_id":"limitbaz", "aggr_limit":"4", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`: true,
+		`{"aggr_id":"limitqux", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:                   true,
+
+		// proxy
+		`{"aggr_id":"proxyfoo", "aggr_limit":4, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:                                     false,
+		`{"aggr_id":"proxybar", "aggr_limit":4, "aggr_proxy":"", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:                    false,
+		`{"aggr_id":"proxyqux", "aggr_limit":4, "aggr_proxy":"https://example.org", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`: false,
+		`{"aggr_id":"proxybaz", "aggr_limit":4, "aggr_proxy":null, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:                  true,
+		`{"aggr_id":"proxyquux", "aggr_limit":4, "aggr_proxy":"example", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:            true,
+		`{"aggr_id":"proxycorge", "aggr_limit":4, "aggr_proxy":4, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:                   true,
+	}
+
+	for data, expectErr := range tc {
+		aggr := new(Aggregation)
+		err := aggr.UnmarshalJSON([]byte(data))
+		receivedErr := (err != nil)
+		if receivedErr != expectErr {
+			if err != nil {
+				fmt.Println(err)
+			}
+			t.Errorf("Expected receivedErr to be %v for '%s'", expectErr, data)
+		}
+	}
+}

--- a/job/job.go
+++ b/job/job.go
@@ -76,6 +76,9 @@ type Job struct {
 
 	// Http client timeout for download in seconds
 	DownloadTimeout int `json:"download_timeout"`
+
+	// The User-Agent to set in download requests
+	UserAgent string `json:"user_agent"`
 }
 
 // MarshalBinary is used by redis driver to marshall custom type State
@@ -187,6 +190,15 @@ func (j *Job) UnmarshalJSON(b []byte) error {
 	}
 	j.DownloadTimeout = timeout
 
+	var useragent string
+	if useragentField, ok := tmp["user_agent"]; ok {
+		useragent, ok = useragentField.(string)
+		if !ok {
+			return errors.New("UserAgent must be a string")
+		}
+	}
+	j.UserAgent = useragent
+
 	return nil
 }
 
@@ -219,6 +231,6 @@ func (j *Job) CallbackInfo(downloadURL url.URL) (Callback, error) {
 
 func (j Job) String() string {
 	return fmt.Sprintf("Job{ID:%s, Aggr:%s, URL:%s, callback_url:%s, "+
-		"callback_type:%s, callback_dst:%s, Timeout:%d}",
-		j.ID, j.AggrID, j.URL, j.CallbackURL, j.CallbackType, j.CallbackDst, j.DownloadTimeout)
+		"callback_type:%s, callback_dst:%s, Timeout:%d, UserAgent:%s}",
+		j.ID, j.AggrID, j.URL, j.CallbackURL, j.CallbackType, j.CallbackDst, j.DownloadTimeout, j.UserAgent)
 }

--- a/job/job.go
+++ b/job/job.go
@@ -73,6 +73,9 @@ type Job struct {
 
 	// Mime type pattern provided by the client
 	MimeType string `json:"mime_type"`
+
+	// Http client timeout for download in seconds
+	DownloadTimeout int `json:"download_timeout"`
 }
 
 // MarshalBinary is used by redis driver to marshall custom type State
@@ -166,9 +169,23 @@ func (j *Job) UnmarshalJSON(b []byte) error {
 		} else {
 			err = errors.New("MimeType pattern must be a string")
 		}
-		return err
+		if err != nil {
+			return err
+		}
 	}
-	j.MimeType = ""
+
+	var timeout int
+	if timeoutS, ok := tmp["download_timeout"]; ok {
+		timeoutf, ok := timeoutS.(float64) // The attribute is given, validate it.
+		if !ok {
+			return errors.New("Download timeout must be a number")
+		}
+		timeout = int(timeoutf)
+		if timeout <= 0 {
+			return errors.New("Download timeout must be greater than 0")
+		}
+	}
+	j.DownloadTimeout = timeout
 
 	return nil
 }
@@ -202,6 +219,6 @@ func (j *Job) CallbackInfo(downloadURL url.URL) (Callback, error) {
 
 func (j Job) String() string {
 	return fmt.Sprintf("Job{ID:%s, Aggr:%s, URL:%s, callback_url:%s, "+
-		"callback_type:%s, callback_dst:%s}",
-		j.ID, j.AggrID, j.URL, j.CallbackURL, j.CallbackType, j.CallbackDst)
+		"callback_type:%s, callback_dst:%s, Timeout:%d}",
+		j.ID, j.AggrID, j.URL, j.CallbackURL, j.CallbackType, j.CallbackDst, j.DownloadTimeout)
 }

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -25,6 +25,14 @@ func TestUnmarshalJSON(t *testing.T) {
 		`{"aggr_id":"foo","url":"http://foobar.com","callback_url":"http://foo.bar"}`:                     false,
 		`{"aggr_id":"foo", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`: false,
 		`{"aggr_id":"foo","url":"http://foobar.com","callback_url":"http://foo.bar","extra":""}`:          false,
+
+		// timeout
+		`{"aggr_id":"timeoutfoo", "download_timeout":12, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:   false,
+		`{"aggr_id":"timeoutfoo", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:                          false,
+		`{"aggr_id":"timeoutfoo", "download_timeout":null, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`: true,
+		`{"aggr_id":"timeoutfoo", "download_timeout":0, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:    true,
+		`{"aggr_id":"timeoutfoo", "download_timeout":-2, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:   true,
+		`{"aggr_id":"timeoutfoo", "download_timeout":"4", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:  true,
 	}
 
 	for data, expectErr := range tc {

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -33,6 +33,13 @@ func TestUnmarshalJSON(t *testing.T) {
 		`{"aggr_id":"timeoutfoo", "download_timeout":0, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:    true,
 		`{"aggr_id":"timeoutfoo", "download_timeout":-2, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:   true,
 		`{"aggr_id":"timeoutfoo", "download_timeout":"4", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:  true,
+
+		// user agent
+		`{"aggr_id":"useragentfoo", "user_agent":"Downloader Test", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`: false,
+		`{"aggr_id":"useragentfoo", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:                                 false,
+		`{"aggr_id":"useragentfoo", "user_agent":"", "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:                false,
+		`{"aggr_id":"useragentfoo", "user_agent":null, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:              true,
+		`{"aggr_id":"useragentfoo", "user_agent":3, "url":"http://foobar.com","callback_url":"http://foo.bar","extra":"whatever"}`:                 true,
 	}
 
 	for data, expectErr := range tc {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -557,7 +557,10 @@ func (wp *workerPool) download(ctx context.Context, j *job.Job, validator *mimet
 		// This actually indicates a malformed url
 		return derrors.E("creating request", err)
 	}
-	if wp.p.UserAgent != "" {
+
+	if j.UserAgent != "" {
+		req.Header.Set("User-Agent", j.UserAgent)
+	} else if wp.p.UserAgent != "" {
 		req.Header.Set("User-Agent", wp.p.UserAgent)
 	}
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -40,6 +40,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -60,28 +61,6 @@ var (
 	// RetryBackoffDuration indicates the time to wait between retries.
 	RetryBackoffDuration = 2 * time.Minute
 	newChecker           = diskcheck.New
-
-	// Based on http.DefaultTransport
-	//
-	// See https://golang.org/pkg/net/http/#RoundTripper
-	httpTransport = &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   5 * time.Second, // was 30 * time.Second
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   4 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		// Bypass tls errors with a few upstream servers (local error: tls: no renegotiation)
-		// We will allow a single server-initiated renegotiation attempt
-		// See:
-		// https://golang.org/pkg/crypto/tls/#RenegotiationSupport
-		// https://github.com/golang/go/issues/5742
-		TLSClientConfig: &tls.Config{Renegotiation: tls.RenegotiateOnceAsClient},
-	}
 )
 
 // TODO: these should all be configuration options provided by the caller
@@ -101,6 +80,7 @@ const (
 	statsResponseCodePrefix        = "download.response."        //Counter
 	statsReaperFailures            = "reaperFailures"            //Counter
 	statsReaperSuccessfulDeletions = "reaperSuccessfulDeletions" //Counter
+	statsInvalidProxies            = "invalidProxies"            //Counter
 
 	// diskChecker settings
 	diskHigh     = 95
@@ -146,6 +126,7 @@ type workerPool struct {
 	p                *Processor
 	numActiveWorkers int32
 	log              *log.Logger
+	client           *http.Client
 
 	// jobChan is the channel that distributes jobs to the respective
 	// workers
@@ -186,17 +167,11 @@ func New(storage *storage.Storage, scanInterval int, storageDir string, logger *
 		return Processor{}, errors.New("Error verifying storage directory is writable: " + err.Error())
 	}
 
-	client := &http.Client{
-		Transport: httpTransport,
-		Timeout:   10 * time.Second, // Larger than Dial + TLS timeout
-	}
-
 	return Processor{
 		Storage:      storage,
 		StorageDir:   storageDir,
 		ScanInterval: scanInterval,
 		StatsIntvl:   5 * time.Second,
-		Client:       client,
 		Log:          logger,
 		pools:        make(map[string]*workerPool),
 		stats:        stats.New("Processor", time.Second, func(m *expvar.Map) {}),
@@ -324,7 +299,12 @@ POOLS_LOOP:
 							p.Log.Printf("Using aggregation with id '%s', and limit: %d",
 								aggr.ID, aggr.Limit)
 						}
-						wp := p.newWorkerPool(aggr)
+						wp, err := p.newWorkerPool(*aggr)
+						if err != nil {
+							p.Log.Printf("Error fetching aggregation with proxy '%s': %s", aggrID, err)
+							p.stats.Add(statsInvalidProxies, 1)
+							continue
+						}
 						p.pools[aggrID] = &wp
 
 						//Report Metrics
@@ -419,15 +399,20 @@ func (p *Processor) collectRogueDownloads() {
 }
 
 // newWorkerPool initializes and returns a WorkerPool for aggr.
-func (p *Processor) newWorkerPool(aggr job.Aggregation) workerPool {
+func (p *Processor) newWorkerPool(aggr job.Aggregation) (workerPool, error) {
 	logPrefix := fmt.Sprintf("%s[worker pool:%s] ", p.Log.Prefix(), aggr.ID)
 
+	client, err := getClient(aggr.Proxy)
+	if err != nil {
+		return workerPool{}, err
+	}
 	return workerPool{
 		aggr:    aggr,
 		jobChan: make(chan job.Job),
 		p:       p,
 		log:     log.New(os.Stderr, logPrefix, log.Ldate|log.Ltime),
-	}
+		client:  client,
+	}, nil
 }
 
 // increaseWorkers atomically increases the activeWorkers counter of wp by 1
@@ -576,7 +561,7 @@ func (wp *workerPool) download(ctx context.Context, j *job.Job, validator *mimet
 		req.Header.Set("User-Agent", wp.p.UserAgent)
 	}
 
-	resp, err := wp.p.Client.Do(req.WithContext(ctx))
+	resp, err := wp.client.Do(req.WithContext(ctx))
 	if err != nil {
 		if strings.Contains(err.Error(), "x509") || strings.Contains(err.Error(), "tls") {
 			wp.p.stats.Add(fmt.Sprintf("%s%s", statsResponseCodePrefix, "tls"), 1)
@@ -761,4 +746,46 @@ func (p *Processor) reaper(ctx context.Context) {
 			p.stats.Add(statsReaperSuccessfulDeletions, 1)
 		}
 	}
+}
+
+func httpTransport(proxy *url.URL) *http.Transport {
+	proxyfunc := http.ProxyFromEnvironment
+	if proxy != nil {
+		proxyfunc = http.ProxyURL(proxy)
+	}
+
+	return &http.Transport{
+		Proxy: proxyfunc,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second, // was 30 * time.Second
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   4 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		// Bypass tls errors with a few upstream servers (local error: tls: no renegotiation)
+		// We will allow a single server-initiated renegotiation attempt
+		// See:
+		// https://golang.org/pkg/crypto/tls/#RenegotiationSupport
+		// https://github.com/golang/go/issues/5742
+		TLSClientConfig: &tls.Config{Renegotiation: tls.RenegotiateOnceAsClient},
+	}
+}
+
+func getClient(proxy string) (*http.Client, error) {
+	var proxyURL *url.URL
+	var err error
+	if proxy != "" {
+		proxyURL, err = url.ParseRequestURI(proxy)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &http.Client{
+		Transport: httpTransport(proxyURL),
+		Timeout:   10 * time.Second,
+	}, nil
 }

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -29,7 +29,7 @@ var (
 	logger           = log.New(os.Stderr, "[test processor]", log.Ldate|log.Ltime|log.Lshortfile)
 	mux              = http.NewServeMux()
 	server           = httptest.NewServer(mux)
-	defaultAggr      = job.Aggregation{ID: "FooBar", Limit: 1}
+	defaultAggr, _   = job.NewAggregation("FooBar", 1, "")
 	defaultProcessor Processor
 	defaultWP        workerPool
 	testCfg          = "../config.test.json"
@@ -71,7 +71,10 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	defaultWP = defaultProcessor.newWorkerPool(defaultAggr)
+	defaultWP, err = defaultProcessor.newWorkerPool(*defaultAggr)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	exit := m.Run()
 
@@ -267,7 +270,7 @@ func TestChecker(t *testing.T) {
 	testChecker.Sick()
 	time.Sleep(10 * time.Millisecond)
 
-	a, _ := job.NewAggregation("foobar", 2)
+	a, _ := job.NewAggregation("foobar", 2, "")
 	store.SaveAggregation(a)
 
 	jobs := []job.Job{

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -407,6 +407,8 @@ func jobFromMap(m map[string]string) (job.Job, error) {
 			if err != nil {
 				return j, fmt.Errorf("Could not decode struct from map: %v", err)
 			}
+		case "UserAgent":
+			j.UserAgent = v
 		default:
 			return j, fmt.Errorf("Field %s with value %s was not found in Job struct", k, v)
 		}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -402,6 +402,11 @@ func jobFromMap(m map[string]string) (job.Job, error) {
 			}
 		case "MimeType":
 			j.MimeType = v
+		case "DownloadTimeout":
+			j.DownloadTimeout, err = strconv.Atoi(v)
+			if err != nil {
+				return j, fmt.Errorf("Could not decode struct from map: %v", err)
+			}
 		default:
 			return j, fmt.Errorf("Field %s with value %s was not found in Job struct", k, v)
 		}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -146,7 +146,7 @@ func New(r *redis.Client) (*Storage, error) {
 //
 // TODO: should we check that the corresponding aggregation exists in redis?
 func (s *Storage) SaveJob(j *job.Job) error {
-	m, err := jobToMap(j)
+	m, err := structToMap(j)
 	if err != nil {
 		return err
 	}
@@ -259,27 +259,31 @@ func (s *Storage) PopRip() (job.Job, error) {
 // GetAggregation fetches from Redis the aggregation denoted by id.
 // In the case of ErrNotFound, the returned aggregation has valid ID and the
 // default limit.
-func (s *Storage) GetAggregation(id string) (job.Aggregation, error) {
-	val, err := s.Redis.HGet(AggrKeyPrefix+id, "Limit").Result()
-	if err == redis.Nil {
-		return job.Aggregation{ID: id, Limit: aggrDefaultLimit}, ErrNotFound
-	}
-
+func (s *Storage) GetAggregation(id string) (*job.Aggregation, error) {
+	val, err := s.Redis.HGetAll(AggrKeyPrefix + id).Result()
 	if err != nil {
-		return job.Aggregation{}, err
+		return nil, err
 	}
 
-	limit, err := strconv.Atoi(val)
-	if err != nil {
-		return job.Aggregation{}, err
+	if v, ok := val["ID"]; !ok || v == "" {
+		aggr, err := job.NewAggregation(id, aggrDefaultLimit, "")
+		if err != nil {
+			return nil, err
+		}
+		return aggr, ErrNotFound
 	}
 
-	return job.Aggregation{ID: id, Limit: limit}, nil
+	aggr, err := AggregationFromMap(val)
+	return &aggr, err
 }
 
 // SaveAggregation updates/creates the current aggregation in redis.
 func (s *Storage) SaveAggregation(a *job.Aggregation) error {
-	return s.Redis.HSet(AggrKeyPrefix+a.ID, "Limit", a.Limit).Err()
+	m, err := structToMap(a)
+	if err != nil {
+		return err
+	}
+	return s.Redis.HMSet(AggrKeyPrefix+a.ID, m).Err()
 }
 
 // RemoveAggregation deletes the aggregation key from Redis
@@ -289,6 +293,27 @@ func (s *Storage) RemoveAggregation(id string) error {
 		return fmt.Errorf("Could not delaggr: %s", err)
 	}
 	return nil
+}
+
+func AggregationFromMap(m map[string]string) (job.Aggregation, error) {
+	var err error
+	aggr := job.Aggregation{}
+	for k, v := range m {
+		switch k {
+		case "ID":
+			aggr.ID = v
+		case "Limit":
+			aggr.Limit, err = strconv.Atoi(v)
+			if err != nil {
+				return aggr, fmt.Errorf("Could not decode struct from map: %v", err)
+			}
+		case "Proxy":
+			aggr.Proxy = v
+		default:
+			return aggr, fmt.Errorf("Field %s with value %s was not found in Aggregarion struct", k, v)
+		}
+	}
+	return aggr, nil
 }
 
 // RetryCallback resets a job's callback state and injects it back to the
@@ -308,17 +333,17 @@ func (s *Storage) RetryCallback(j *job.Job) error {
 	return s.QueuePendingCallback(j, 0)
 }
 
-func jobToMap(j *job.Job) (map[string]interface{}, error) {
+func structToMap(str interface{}) (map[string]interface{}, error) {
 	out := make(map[string]interface{})
 
-	v := reflect.ValueOf(j)
+	v := reflect.ValueOf(str)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
 
 	// we only accept structs
 	if v.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("jobToMap only accepts structs; got %T", v)
+		return nil, fmt.Errorf("structToMap only accepts structs; got %T", v)
 	}
 
 	typ := v.Type()

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -69,7 +69,7 @@ func TestPendingJob(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	aggr, err := job.NewAggregation(testJob.AggrID, 8)
+	aggr, err := job.NewAggregation(testJob.AggrID, 8, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestRetryCallback(t *testing.T) {
 func TestRemoveAggregationWithNoJobs(t *testing.T) {
 	Redis.FlushDB()
 
-	testAggr, _ := job.NewAggregation(testJob.AggrID, 8)
+	testAggr, _ := job.NewAggregation(testJob.AggrID, 8, "")
 	storage.SaveAggregation(testAggr)
 	err := storage.RemoveAggregation(testAggr.ID)
 	if err != nil {
@@ -139,7 +139,7 @@ func TestRemoveAggregationWithNoJobs(t *testing.T) {
 func TestRemoveAggregationWithJobs(t *testing.T) {
 	Redis.FlushDB()
 
-	testAggr, _ := job.NewAggregation(testJob.AggrID, 8)
+	testAggr, _ := job.NewAggregation(testJob.AggrID, 8, "")
 	storage.SaveAggregation(testAggr)
 	storage.QueuePendingDownload(&testJob, 0)
 
@@ -156,7 +156,7 @@ func TestRemoveAggregationWithJobs(t *testing.T) {
 func TestGetAggregation(t *testing.T) {
 	Redis.FlushDb()
 
-	existingAggr, _ := job.NewAggregation("existingID", 8)
+	existingAggr, _ := job.NewAggregation("existingID", 8, "")
 	storage.SaveAggregation(existingAggr)
 	testCases := []string{
 		existingAggr.ID,


### PR DESCRIPTION
Add 3 new optional configurations for downloader API:

### Add HTTP proxy support per aggregation
A new API option, `aggr_proxy` is added to support different proxy per aggregation request. If no proxy is given or it is an empty string, the previous behaviour will be followed, read from environment though `ProxyFromEnvironment`.
 
### Configure Http Client Download timeout per job  
Add a new API option, `download_timeout` to configure separately http client timeout per job.

Default timeout has been removed, for the case that
- user gives a timeout bigger than the default: it isn't respected and the default timeout is dominant.

We decided to avoid this inconsistency by removing completely the timeout from the client.

Timeout will be applied only if it is send with the rest of Job's configuration, with this new API option `download_timeout`. Otherwise there will be no timeout for the download client.

### Configure different UserAgent per Job
Add a new API option, `user_agent` to configure separately a different http user agent per job request. If the argument is not provided, the default UserAgent will be used from the Processor configuration.