### PR TITLE
Differentiate the initial try from the retries

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -67,7 +67,7 @@ var (
 const (
 	workerMaxInactivity = 5 * time.Second
 	backoffDuration     = 1 * time.Second
-	maxDownloadRetries  = 3
+	maxDownloadRetries  = 2
 
 	//Metric Identifiers
 	statsMaxWorkers                = "maxWorkers"                //Gauge
@@ -688,7 +688,7 @@ func (wp *workerPool) perform(ctx context.Context, j *job.Job, validator *mimety
 // and retries the job if its RetryCount < maxRetries else it marks
 // it as failed
 func (wp *workerPool) requeueOrFail(j *job.Job, err string) error {
-	if j.DownloadCount >= maxDownloadRetries {
+	if j.DownloadCount > maxDownloadRetries {
 		return wp.markJobFailed(j, err)
 	}
 	return wp.p.Storage.QueuePendingDownload(j, time.Duration(j.DownloadCount)*RetryBackoffDuration)


### PR DESCRIPTION
Working on implementing the `max-retries` option https://github.com/skroutz/downloader/pull/17 surfaced a logical
error implemented in the retry mechanism.

We treat the original request as a *retry*.

The commit changes the number of default max retries to 2 (from 3) and
we now check the download count against the real number of retries allowed.

The tests do not require any changes since the implemented behavior is the
same.

We had:

```
1 retry
2 retries
3 retries
```
Now we have:

```
try
1 retry
2 retries
```

EDIT:

The flow goes as follows:

```
for retries=2

count=1
perform download #1 

count > retries false

count=2
perform download #2

count > retries false 

count=3
perform download #3

count > retries true
exit
```