### PR TITLE
Add docker image for downloader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.14'
+          go-version: '1.18'
       - name: Checkout downloader
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           go-version: '1.14'
       - name: Checkout downloader
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup cache
         uses: actions/cache@v2
         with:
@@ -31,4 +33,3 @@ jobs:
             ${{ runner.os }}-go-
       - name: Test
         run: make check
-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build_publish:
+    if: ${{ github.event.base_ref == 'refs/heads/master' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout downloader
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=true
+          tags: |
+            type=semver,pattern={{raw}}
+            type=sha,enable=true
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ config.json
 *.swp
 .*
 *~
+
+# Do not ignore workflows
+!.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /srv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.14 as builder
+
+WORKDIR /srv
+
+COPY . /srv
+
+RUN apt-get update \
+    && apt-get install -y librdkafka-dev libmagic-dev \
+    && make
+
+
+FROM debian:bullseye-slim
+
+RUN apt-get update \
+    && apt-get install -y librdkafka-dev libmagic-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -r downloader \
+    && useradd --no-log-init --shel /bin/bash -r -g downloader downloader
+
+COPY --chown=downloader:downloader --from=builder \
+        /srv/downloader /srv/config.json.sample /srv/
+
+USER downloader
+WORKDIR /srv
+
+ENTRYPOINT [ "/srv/downloader" ]
+CMD [ "--help" ]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/skroutz/downloader
 
-go 1.14
+go 1.18
 
 require (
 	github.com/agis/spawn v0.0.0-20180921114948-ff42eda08af2


### PR DESCRIPTION
Adds a Dockerfile for downloader. This can be used for deploying downloader in a dockerized environment or for local testing in environments without support for the required dependencies.

Updates Actions to include building, tagging and publishing a docker image release under `ghcr.io/skroutz/downloader` when pushing a tag on `master` branch _only_.