### PR TITLE
Trigger the CI workflow on pushes to master only and on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
When "on: [push, pull_request]" is specified in the GitHub workflow
for every push on a branch that is part of a PR the workflow runs twice.

With this change, run the CI once on PRs and pushes to master.