### PR TITLE
Allow multiple downloaders to use the same redis

### DIFF
--- a/job/aggregation.go
+++ b/job/aggregation.go
@@ -6,6 +6,9 @@ import (
 	"net/url"
 )
 
+// Idle time after which an aggregation will become available for another processor
+const AggregationTimeout = 300 // 5m in seconds
+
 // Aggregation is the concept through which the rate limit rules are defined
 // and enforced.
 type Aggregation struct {
@@ -16,11 +19,15 @@ type Aggregation struct {
 
 	// Proxy url for the client to use, optional
 	Proxy string `json:"aggr_proxy"`
+
+	// Unix Timestamp. Indicates if an aggregation is currently being processed.
+	// If this is set, a new processor will not pick up the aggregation.
+	ExpiresAt string `json:"-"`
 }
 
 // NewAggregation creates an aggregation with the provided ID and limit.
 // If any of the prerequisites fail, an error is returned.
-func NewAggregation(id string, limit int, proxy string) (*Aggregation, error) {
+func NewAggregation(id string, limit int, proxy string, expiresAt string) (*Aggregation, error) {
 	if id == "" {
 		return nil, errors.New("Aggregation ID cannot be empty")
 	}
@@ -33,7 +40,8 @@ func NewAggregation(id string, limit int, proxy string) (*Aggregation, error) {
 			return nil, errors.New("Aggregation proxy must be a valid URI: " + err.Error())
 		}
 	}
-	return &Aggregation{ID: id, Limit: limit, Proxy: proxy}, nil
+
+	return &Aggregation{ID: id, Limit: limit, Proxy: proxy, ExpiresAt: expiresAt}, nil
 }
 
 // UnmarshalJSON populates the aggregation with the values in the provided JSON.
@@ -76,9 +84,18 @@ func (a *Aggregation) UnmarshalJSON(b []byte) error {
 		}
 	}
 
+	var expiresAt string
+	if expiresAtField, ok := tmp["expiresAt"]; ok {
+		expiresAt, ok = expiresAtField.(string)
+		if !ok {
+			return errors.New("Aggregation expiresAt must be a string")
+		}
+	}
+
 	a.ID = id
 	a.Limit = limit
 	a.Proxy = proxy
+	a.ExpiresAt = expiresAt
 
 	return nil
 }

--- a/processor/download_test.go
+++ b/processor/download_test.go
@@ -29,7 +29,7 @@ func TestPerformWithDefaultRequestHeaders(t *testing.T) {
 		"Accept-Encoding": "gzip,deflate,br",
 	}
 
-	aggregation, err := job.NewAggregation("FooBarBaz", 1, "")
+	aggregation, err := job.NewAggregation("FooBarBaz", 1, "", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestPerformWithJobRequestHeaders(t *testing.T) {
 		"Accept":     "*/*",
 	}
 
-	aggregation, err := job.NewAggregation("FooBarBaz", 1, "")
+	aggregation, err := job.NewAggregation("FooBarBaz", 1, "", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	a, err := job.NewAggregation("proxyfoo", 2, "http://www.example.com")
+	a, err := job.NewAggregation("proxyfoo", 2, "http://www.example.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -71,7 +71,7 @@ func TestPendingJob(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	aggr, err := job.NewAggregation(testJob.AggrID, 8, "")
+	aggr, err := job.NewAggregation(testJob.AggrID, 8, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func TestRetryCallback(t *testing.T) {
 func TestRemoveAggregationWithNoJobs(t *testing.T) {
 	Redis.FlushDB()
 
-	testAggr, _ := job.NewAggregation(testJob.AggrID, 8, "")
+	testAggr, _ := job.NewAggregation(testJob.AggrID, 8, "", "")
 	storage.SaveAggregation(testAggr)
 	err := storage.RemoveAggregation(testAggr.ID)
 	if err != nil {
@@ -141,7 +141,7 @@ func TestRemoveAggregationWithNoJobs(t *testing.T) {
 func TestRemoveAggregationWithJobs(t *testing.T) {
 	Redis.FlushDB()
 
-	testAggr, _ := job.NewAggregation(testJob.AggrID, 8, "")
+	testAggr, _ := job.NewAggregation(testJob.AggrID, 8, "", "")
 	storage.SaveAggregation(testAggr)
 	storage.QueuePendingDownload(&testJob, 0)
 
@@ -158,7 +158,7 @@ func TestRemoveAggregationWithJobs(t *testing.T) {
 func TestGetAggregation(t *testing.T) {
 	Redis.FlushDb()
 
-	existingAggr, _ := job.NewAggregation("existingID", 8, "")
+	existingAggr, _ := job.NewAggregation("existingID", 8, "", "")
 	storage.SaveAggregation(existingAggr)
 	testCases := []string{
 		existingAggr.ID,


### PR DESCRIPTION
In order to enable multiple processor instances run on the same redis we need
to make sure that each aggregation is only processed by one processor. Moreover
we need to make sure that if a processor dies, all of the corresponding jobs
are requeued.

This is achieved by adding `ExpiresAt` field on Aggregation. It is a Unix
Timestamp and is set when a processor picks up an aggregation. Regularly in the
processor loop, this expiration is refreshed so as to indicate that the
aggregation is still being processed and the processor is still alive.

In the event that a processor dies while an Aggregation is being processed,
we need to wait the Aggregation expiration time and then a new processor will
pick up the aggregation and requeue only the jobs that are left in `InProgress`
state. This refactors the logic behind `collectRogueDownloads()` as it is now
automated.