### PR TITLE
Pin docker-compose redis image to 6-alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       redis:
-        image: redis
+        image: redis:6-alpine
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.3"
 services:
   redis:
-    image: "redis:alpine"
+    image: "redis:6-alpine"
     ports:
       - 6379:6379


### PR DESCRIPTION
redis:latest now points to redis version 7 on docker hub which breaks the CI with a "Could not zpop: ERR EMPTY" error. Pinning at least the major part of the version ensures better CI consistency.