### PR TITLE
Explicitely add replication mode for aggrpop

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -127,6 +127,9 @@ var (
 	aggrpop = redis.NewScript(`
 			local aggr = KEYS[1]
 			local timeout = KEYS[2]
+			
+			-- required replication method for redis < 5.0
+			redis.replicate_commands()
 
 			-- get current unix timestamp
 			local cUnixTimestamp = tonumber(redis.call("time")[1])


### PR DESCRIPTION
There are two replication modes available for redis, script and commands
(aka effects replication). Script replication executes the same script on
replicas after the execution of the first one has finished. Effects replication
executes each write command on all replicas and then moves on to the next one.

Script replication is the default until redis v5.0 where it was switched
for effects replication. After redis v7.0 it is the only replication method
supported.

Effects replication is required for non-deterministic commands, such as time,
in order to guarantee consistency across replicas. For compatibility reasons,
we explicitely set replication mode to effects on `aggropop`.