### PR TITLE
Add Sentinel failover support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,11 @@ import (
 type Config struct {
 	Redis struct {
 		Addr string `json:"addr"`
+		// Sentinel settings
+		// List of Sentinel Hosts
+		Sentinel []string `json:"sentinel"`
+		// Sentinel Master Name
+		MasterName string `json:"master_name"`
 	} `json:"redis"`
 
 	API struct {


### PR DESCRIPTION
This allows downloader to handle redis failover events. When a Redis host is no
longer available, Sentinel will fire the `+switch-master` event which is
picked up by a redis client to sentinel using PSubscribe.

In the event of a failover, a new redis connection is being established. If it
succeeds, this new client will be used by all goroutines to resume operation.
If it fails, this is considered fatal and a shutdown is initiated.