### PR TITLE
Set download_url as a job property when processing a job

### DIFF
--- a/backend/http_backend/http_backend_test.go
+++ b/backend/http_backend/http_backend_test.go
@@ -52,7 +52,7 @@ func TestHttpBackendNotifySucess(t *testing.T) {
 		t.Fatalf("Start should not return error")
 	}
 
-	cbInfoS, _ := jobS.CallbackInfo(*dwURL)
+	cbInfoS, _ := jobS.CallbackInfo()
 
 	wg.Add(1)
 	go func() {

--- a/config.test.json
+++ b/config.test.json
@@ -6,6 +6,7 @@
 		"heartbeat_path":"/tmp/disable_api"
 	},
 	"processor": {
+		"download_url": "http://localhost/foo",
 		"storage_dir":"/tmp/",
 		"request_headers": {
 			"Accept": "*/*",
@@ -14,7 +15,6 @@
 		"stats_interval": 300
 	},
 	"notifier": {
-		"download_url": "http://localhost/foo",
 		"concurrency": 10,
 		"stats_interval": 300,
 		"deletion_interval": 1

--- a/config/config.go
+++ b/config/config.go
@@ -25,13 +25,13 @@ type Config struct {
 		StorageBackend map[string]string `json:"filestorage"`
 		RequestHeaders map[string]string `json:"request_headers"`
 		StatsInterval  int               `json:"stats_interval"`
+		DownloadURL    string            `json:"download_url"`
 	} `json:"processor"`
 
 	Notifier struct {
-		DownloadURL      string `json:"download_url"`
-		Concurrency      int    `json:"concurrency"`
-		StatsInterval    int    `json:"stats_interval"`
-		DeletionInterval int    `json:"deletion_interval"`
+		Concurrency      int `json:"concurrency"`
+		StatsInterval    int `json:"stats_interval"`
+		DeletionInterval int `json:"deletion_interval"`
 	} `json:"notifier"`
 
 	Backends map[string]map[string]interface{}

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -244,7 +244,7 @@ FILECHECK:
 		case <-time.After(timeout):
 			t.Fatal("File not present on the download location after 5 seconds")
 		default:
-			relativePath := strings.TrimPrefix(downloadURI.String(), cfg.Notifier.DownloadURL)
+			relativePath := strings.TrimPrefix(downloadURI.String(), cfg.Processor.DownloadURL)
 			filePath := path.Join(cfg.Processor.StorageDir, relativePath)
 			downloaded, err = os.Open(filePath)
 			if err == nil {

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -62,7 +62,7 @@ func TestJobToString(t *testing.T) {
 	testJob := Job{}
 	res := testJob.String()
 	expected := "Job{ID:, Aggr:, URL:, ExtractImageSize:false, ImageSize: , " +
-		"callback_url:, callback_type:, callback_dst:, Timeout:0, RequestHeaders:map[]}"
+		"callback_url:, callback_type:, callback_dst:, Timeout:0, RequestHeaders:map[], DownloadURL:}"
 
 	if res != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, res)

--- a/main.go
+++ b/main.go
@@ -196,7 +196,7 @@ func main() {
 						logger.Fatalf("Unknown filestorage type %s", cfg.Processor.StorageBackend["type"])
 					}
 				}
-				processor, err := processor.New(storage_o, 3, cfg.Processor.StorageDir, logger, fstorage)
+				processor, err := processor.New(storage_o, 3, cfg.Processor.StorageDir, logger, fstorage, cfg.Processor.DownloadURL)
 				if err != nil {
 					return err
 				}
@@ -270,7 +270,7 @@ func main() {
 					return err
 				}
 				logger := log.New(os.Stderr, "[notifier] ", log.Ldate|log.Ltime)
-				notifier, err := notifier.New(storage_o, cfg.Notifier.Concurrency, logger, cfg.Notifier.DownloadURL)
+				notifier, err := notifier.New(storage_o, cfg.Notifier.Concurrency, logger)
 				if err != nil {
 					logger.Fatal(err)
 				}

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -57,7 +57,7 @@ func TestUndefinedBackend(t *testing.T) {
 		CallbackType:  "foo",
 		CallbackDst:   cbServer.URL}
 
-	notifier, err := New(store, 10, logger, "http://blah.com/")
+	notifier, err := New(store, 10, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestNotifyJobDeletion(t *testing.T) {
 	}
 
 	statsID = "jobdeletion"
-	notifier, err := New(store, 10, logger, "http://blah.com/")
+	notifier, err := New(store, 10, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestNotifyJobDeletion(t *testing.T) {
 
 func TestRogueCollection(t *testing.T) {
 	statsID = "rogue"
-	notifier, err := New(store, 10, logger, "http://blah.com/")
+	notifier, err := New(store, 10, logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/processor/download_test.go
+++ b/processor/download_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestPerformWithDefaultRequestHeaders(t *testing.T) {
-	processor, err := New(store, 1, storageDir, logger, fileStorage)
+	processor, err := New(store, 1, storageDir, logger, fileStorage, defaultProcessor.DownloadURL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestPerformWithDefaultRequestHeaders(t *testing.T) {
 }
 
 func TestPerformWithJobRequestHeaders(t *testing.T) {
-	processor, err := New(store, 1, storageDir, logger, fileStorage)
+	processor, err := New(store, 1, storageDir, logger, fileStorage, defaultProcessor.DownloadURL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestPerformWithJobRequestHeaders(t *testing.T) {
 func TestProxy(t *testing.T) {
 	var wg sync.WaitGroup
 	//Since we are messing with the default settings, we create a new processor here
-	p, err := New(store, 1, storageDir, logger, fileStorage)
+	p, err := New(store, 1, storageDir, logger, fileStorage, defaultProcessor.DownloadURL)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -3,7 +3,6 @@ package processor
 import (
 	"context"
 	"fmt"
-	"github.com/skroutz/downloader/processor/filestorage"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -14,6 +13,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/skroutz/downloader/processor/filestorage"
 
 	"github.com/go-redis/redis"
 	"github.com/skroutz/downloader/config"
@@ -68,7 +69,7 @@ func TestMain(m *testing.M) {
 	}
 	newChecker = func(string, int, int, time.Duration) (diskcheck.Checker, error) { return testChecker, nil }
 
-	defaultProcessor, err = New(store, 3, storageDir, logger, fileStorage)
+	defaultProcessor, err = New(store, 3, storageDir, logger, fileStorage, cfg.Processor.DownloadURL)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -583,6 +583,8 @@ func jobFromMap(m map[string]string) (job.Job, error) {
 			j.S3Bucket = v
 		case "S3Region":
 			j.S3Region = v
+		case "DownloadURL":
+			j.DownloadURL = v
 		default:
 			return j, fmt.Errorf("Field %s with value %s was not found in Job struct", k, v)
 		}


### PR DESCRIPTION
download_url was returned by the notifier in the job callbacks
as set in config.json.

When multiple downloaders were running with a common redis but
a separate filesystem, jobs handled by processor A would save
the files on filesytem A, but when notifier B dispatched the
callbacks for the same jobs, it would return a download_url
pointing to its own filesystem. Because the filesystem is
not common in this scenario, the downloads would fail with
404.

This change moves the download_url ownership to the processor
component and sets it as an attribute to each job after successful
downloading. This ensures that regardless of which notifier
processes the job callback, the download_url will be correct.

Breaking change in config.json: downloader_url must be set
in the processor section instead of the notifier section.