### PR TITLE
processor: Pass extra json as metadata to s3 objects

### DIFF
--- a/processor/filestorage/filestorage.go
+++ b/processor/filestorage/filestorage.go
@@ -4,6 +4,7 @@ package filestorage
 // to save downloaded files
 type FileStorage interface {
 	StoreFile(srcpath string, destpath string) error
+	StoreFileWithMetadata(srcpath string, destpath string, metadata map[string]interface{}) error
 	DeleteFile(filepath string) error
 	FileExists(filepath string) bool
 }

--- a/processor/filestorage/fileystem.go
+++ b/processor/filestorage/fileystem.go
@@ -1,6 +1,7 @@
 package filestorage
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -49,6 +50,13 @@ func (fs FileSystem) StoreFile(srcpath string, destpath string) error {
 	}
 
 	return nil
+}
+
+// StoreFileWithTags simply calls StoreFiles since we can't handle tags in this
+// backend
+func (fs FileSystem) StoreFileWithMetadata(srcpath string, destpath string, metadata map[string]interface{}) error {
+	fmt.Fprintf(os.Stderr, "[WARN] StoreFileWithTags called from filesystem backend. Metadata are ignored\n")
+	return fs.StoreFile(srcpath, destpath)
 }
 
 // DeleteFile removes a file from the filesystem storage


### PR DESCRIPTION
When writting to s3 all the information present to the `extra` field
gets discarded.

This commit tries (best-effort) to write all string and numeric values
as S3 metadata to the uploaded object. Note that all numeric values are
treated as `int64`.